### PR TITLE
Added omit characters

### DIFF
--- a/PasswordGenerator.Tests/OmitCharactersTests.cs
+++ b/PasswordGenerator.Tests/OmitCharactersTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PasswordGenerator.Tests
+{
+    public class OmitCharactersTests
+    {
+        [Test]
+        public void TestOmit_IlO0B8()
+        {
+            var charactersToOmit = "IlO0B8";
+            var pwd = new Password(true, true, true, true, charactersToOmit, 8, 100);
+            var result = pwd.NextGroup(1000);
+
+            foreach (var password in result)
+            {
+                var index = password.IndexOfAny(charactersToOmit.ToCharArray());
+                Assert.AreEqual(-1, index);
+            }
+        }
+
+        [Test]
+        public void TestNotOmit_IlO0B8()
+        {
+            var pwd = new Password(true, true, true, true, null, 8, 100);
+            var result = pwd.NextGroup(1000);
+
+            var charactersToOmit = "IlO0B8";
+            long hasOmitedCharacters = 0;
+            foreach (var password in result)
+            {
+                var index = password.IndexOfAny(charactersToOmit.ToCharArray());
+                if (index >= 0)
+                    hasOmitedCharacters++;
+            }
+
+            Assert.IsTrue(hasOmitedCharacters > 0);
+        }
+    }
+}

--- a/PasswordGenerator/IPasswordSettings.cs
+++ b/PasswordGenerator/IPasswordSettings.cs
@@ -20,5 +20,6 @@ namespace PasswordGenerator
         IPasswordSettings AddSpecial();
         IPasswordSettings AddSpecial(string specialCharactersToAdd);
         string SpecialCharacters { get; set; }
+        string OmitCharacters { get; }
     }
 }

--- a/PasswordGenerator/Password.cs
+++ b/PasswordGenerator/Password.cs
@@ -17,13 +17,14 @@ namespace PasswordGenerator
         private const bool DefaultIncludeUppercase = true;
         private const bool DefaultIncludeNumeric = true;
         private const bool DefaultIncludeSpecial = true;
+        private const string DefaultOmitCharacters = null;
         private static RNGCryptoServiceProvider _rng;
 
         public Password()
         {
             Settings = new PasswordSettings(DefaultIncludeLowercase, DefaultIncludeUppercase,
                 DefaultIncludeNumeric, DefaultIncludeSpecial, DefaultPasswordLength, DefaultMaxPasswordAttempts,
-                true);
+                true, DefaultOmitCharacters);
 
             _rng = new RNGCryptoServiceProvider();
         }
@@ -38,7 +39,8 @@ namespace PasswordGenerator
         public Password(int passwordLength)
         {
             Settings = new PasswordSettings(DefaultIncludeLowercase, DefaultIncludeUppercase,
-                DefaultIncludeNumeric, DefaultIncludeSpecial, passwordLength, DefaultMaxPasswordAttempts, true);
+                DefaultIncludeNumeric, DefaultIncludeSpecial, passwordLength, DefaultMaxPasswordAttempts, true,
+                DefaultOmitCharacters);
             
             _rng = new RNGCryptoServiceProvider();
         }
@@ -46,7 +48,7 @@ namespace PasswordGenerator
         public Password(bool includeLowercase, bool includeUppercase, bool includeNumeric, bool includeSpecial)
         {
             Settings = new PasswordSettings(includeLowercase, includeUppercase, includeNumeric,
-                includeSpecial, DefaultPasswordLength, DefaultMaxPasswordAttempts, false);
+                includeSpecial, DefaultPasswordLength, DefaultMaxPasswordAttempts, false, DefaultOmitCharacters);
 
             _rng = new RNGCryptoServiceProvider();
         }
@@ -55,7 +57,7 @@ namespace PasswordGenerator
             int passwordLength)
         {
             Settings = new PasswordSettings(includeLowercase, includeUppercase, includeNumeric,
-                includeSpecial, passwordLength, DefaultMaxPasswordAttempts, false);
+                includeSpecial, passwordLength, DefaultMaxPasswordAttempts, false, DefaultOmitCharacters);
 
             _rng = new RNGCryptoServiceProvider();
         }
@@ -64,7 +66,16 @@ namespace PasswordGenerator
             int passwordLength, int maximumAttempts)
         {
             Settings = new PasswordSettings(includeLowercase, includeUppercase, includeNumeric,
-                includeSpecial, passwordLength, maximumAttempts, false);
+                includeSpecial, passwordLength, maximumAttempts, false, DefaultOmitCharacters);
+
+            _rng = new RNGCryptoServiceProvider();
+        }
+
+        public Password(bool includeLowercase, bool includeUppercase, bool includeNumeric, bool includeSpecial,
+            string omitCharacters ,int passwordLength, int maximumAttempts)
+        {
+            Settings = new PasswordSettings(includeLowercase, includeUppercase, includeNumeric,
+                includeSpecial, passwordLength, maximumAttempts, false, omitCharacters);
 
             _rng = new RNGCryptoServiceProvider();
         }

--- a/PasswordGenerator/PasswordGeneratorSettings.cs
+++ b/PasswordGenerator/PasswordGeneratorSettings.cs
@@ -5,7 +5,7 @@
         public PasswordGeneratorSettings(bool includeLowercase, bool includeUppercase, bool includeNumeric, 
             bool includeSpecial, int passwordLength, int maximumAttempts, bool usingDefaults) 
             : base(includeLowercase, includeUppercase, includeNumeric, 
-                includeSpecial, passwordLength, maximumAttempts, usingDefaults)
+                includeSpecial, passwordLength, maximumAttempts, usingDefaults, null)
         {
         }
     }

--- a/PasswordGenerator/PasswordSettings.cs
+++ b/PasswordGenerator/PasswordSettings.cs
@@ -14,9 +14,10 @@ namespace PasswordGenerator
         private const int DefaultMinPasswordLength = 4;
         private const int DefaultMaxPasswordLength = 256;
         public string SpecialCharacters { get; set; }
+        public string OmitCharacters { get; private set; }
 
         public PasswordSettings(bool includeLowercase, bool includeUppercase, bool includeNumeric, bool includeSpecial,
-            int passwordLength, int maximumAttempts, bool usingDefaults)
+            int passwordLength, int maximumAttempts, bool usingDefaults, string omitCharacters)
         {
             IncludeLowercase = includeLowercase;
             IncludeUppercase = includeUppercase;
@@ -28,6 +29,8 @@ namespace PasswordGenerator
             MaximumLength = DefaultMaxPasswordLength;
             UsingDefaults = usingDefaults;
             SpecialCharacters = DefaultSpecialCharacters;
+            OmitCharacters = omitCharacters;
+
             CharacterSet = BuildCharacterSet(includeLowercase, includeUppercase, includeNumeric, includeSpecial);
         }
 
@@ -96,7 +99,16 @@ namespace PasswordGenerator
             if (includeNumeric) characterSet.Append(NumericCharacters);
 
             if (includeSpecial) characterSet.Append(SpecialCharacters);
+
+            if (!string.IsNullOrEmpty(OmitCharacters)) RemoveOmittedCharacters(characterSet);
+
             return characterSet.ToString();
+        }
+
+        private void RemoveOmittedCharacters(StringBuilder characterSet)
+        {
+            foreach (var character in OmitCharacters)
+                characterSet.Replace(character.ToString(), string.Empty);
         }
 
         private void StopUsingDefaults()


### PR DESCRIPTION
Hi.

Our users complains that some characters are easy to mistake with other ones (eg.: "I":"l", "O":"0", "B":"8"). So I wrote some code which add possibility to omit characters in generated passwords. If you like it, fill free to add it to your repository. 