### PR TITLE
When no valid password could be generated, throw an Exception if desired

### DIFF
--- a/PasswordGenerator.Tests/BasicTests.cs
+++ b/PasswordGenerator.Tests/BasicTests.cs
@@ -117,6 +117,23 @@ namespace PasswordGenerator.Tests
             string result = pwd.Next();
             Assert.AreEqual(21,result.Length);
         }
+        
+        [Test]
+        public void PasswordGenerator_ThrowOnMaximumAttemptsExceededEnabled_ShouldThrow()
+        {
+            Assert.Throws<MaximumAttemptsExceededException>(() =>
+            {
+                // Multiple attempts are needed to make sure the test throws
+                for (int i = 0; i < 1000; i++)
+                {
+                    // Maximum complexity, minimal allowed attempts
+                    var pwd = new Password(includeLowercase: true, includeUppercase: true, includeNumeric: true, includeSpecial: true, passwordLength: 4, maximumAttempts: 1)
+                        .ThrowOnMaximumAttemptsExceeded();
+                    
+                    pwd.Next();
+                }
+            });
+        }
 
         [Test]
         public void PasswordGenerator_NoLengthTest_ShouldNotThrowAnError()

--- a/PasswordGenerator/MaximumAttemptsExceededException.cs
+++ b/PasswordGenerator/MaximumAttemptsExceededException.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace PasswordGenerator
+{
+    /// <summary>
+    /// Represents errors that occurs during random password generation when the configured maximum attempts are exceeded.
+    /// </summary>
+    [Serializable]
+    public sealed class MaximumAttemptsExceededException : Exception
+    {
+        public MaximumAttemptsExceededException()
+        {
+        }
+
+        private MaximumAttemptsExceededException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes Issue #13 - Should throw instead of returning "Try again" when a valid password cannot be found